### PR TITLE
Fixbug #73 Убраны лишние символы \n из ответа сервера

### DIFF
--- a/mod/api.py
+++ b/mod/api.py
@@ -83,10 +83,9 @@ class ValidJSON(BaseModel):
     jsonapi: Optional[Version] = None
     meta: Optional[Any] = None
 
-    def toJSON(self, sort_keys=False, indent=4):
+    def toJSON(self):
         return json.dumps(self,
-                          sort_keys=sort_keys,
-                          indent=indent,
+                          ensure_ascii=False,
                           default=lambda o: o.__dict__)
 
 


### PR DESCRIPTION
При формировании ответа сервера изменены настройки отступов и выключен параметр ensure_ascii