### PR TITLE
Repair controller.py to return user email for himself, return messages uuid

### DIFF
--- a/mod/controller.py
+++ b/mod/controller.py
@@ -343,6 +343,7 @@ class ProtocolMethods:
         def get_messages(db, end: int, start: int = 0) -> None:
             for element in db[start:end]:
                 message = api.Message()
+                message.uuid = element.uuid
                 message.from_flow = element.flow.uuid
                 message.from_user = element.user.uuid
                 message.text = element.text
@@ -466,6 +467,8 @@ class ProtocolMethods:
                     user.is_bot = dbquery.isBot
                     user.avatar = dbquery.avatar
                     user.bio = dbquery.bio
+                    if dbquery.uuid == self.request.data.user[0].uuid:
+                        user.email = dbquery.email
                     self.response.data.user.append(user)
             logger.success("\'_user_info\' executed successfully")
             self.__catching_error(200)

--- a/mod/controller.py
+++ b/mod/controller.py
@@ -467,8 +467,6 @@ class ProtocolMethods:
                     user.is_bot = dbquery.isBot
                     user.avatar = dbquery.avatar
                     user.bio = dbquery.bio
-                    if dbquery.uuid == self.request.data.user[0].uuid:
-                        user.email = dbquery.email
                     self.response.data.user.append(user)
             logger.success("\'_user_info\' executed successfully")
             self.__catching_error(200)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -700,7 +700,7 @@ class TestAllMessages(unittest.TestCase):
                              cascade=True)
         del self.test
 
-    def test_all_message_message_fields_filled(self):
+    def test_all_message_fields_filled(self):
         self.test.data.flow[0].uuid = "07d950"
         run_method = controller.ProtocolMethods(self.test)
         result = json.loads(run_method.get_response())

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -685,7 +685,7 @@ class TestAllMessages(unittest.TestCase):
                            time=item,
                            user=new_user2,
                            flow=new_flow2)
-        models.Message(uuid=str(uuid4().int),
+        models.Message(uuid='271520724063176879757028074376756118591',
                        text="Privet",
                        time=666,
                        user=new_user2,
@@ -699,6 +699,21 @@ class TestAllMessages(unittest.TestCase):
                              dropJoinTables=True,
                              cascade=True)
         del self.test
+
+    def test_all_message_message_fields_filled(self):
+        self.test.data.flow[0].uuid = "07d950"
+        run_method = controller.ProtocolMethods(self.test)
+        result = json.loads(run_method.get_response())
+        message_found = False
+        for _, item in enumerate(result["data"]["message"]):
+            if item["time"] == 666:
+                message_found = True
+                self.assertEqual(item["uuid"], '271520724063176879757028074376756118591')
+                self.assertEqual(item["text"], 'Privet')
+                self.assertEqual(item["from_user"], '654321')
+                self.assertEqual(item["from_flow"], '07d950')
+                break
+        self.assertTrue(message_found)
 
     def test_all_message_more_limit(self):
         run_method = controller.ProtocolMethods(self.test)


### PR DESCRIPTION
Закрыть эти issues #117 #118

Для метода user_info проверяем - если клиент запрашивает свои данные, то выдаем больше полей чем о других, на данном этапе только email но в дальнейшем возможно будут какие то настройки хранящиеся в аккаунте.

Для метода all_users не возвращался uuid - что не позволяло идентифицировать сообщение на клиенте и избежать дублей.