### PR TITLE
Актуализация протокола MTP в коде сервера

### DIFF
--- a/mod/db/dbhandler.py
+++ b/mod/db/dbhandler.py
@@ -340,6 +340,7 @@ class DBHandler:
                  username: str = None,
                  is_bot: bool = False,
                  auth_id: str = None,
+                 token_ttl: int = None,
                  email: str = None,
                  avatar: bytes = None,
                  bio: str = None,
@@ -381,6 +382,7 @@ class DBHandler:
                                username=username,
                                is_bot=is_bot,
                                auth_id=auth_id,
+                               token_ttl=token_ttl,
                                email=email,
                                avatar=avatar,
                                bio=bio,
@@ -395,6 +397,7 @@ class DBHandler:
                     username: str = None,
                     is_bot: bool = False,
                     auth_id: str = None,
+                    token_ttl: int = None,
                     email: str = None,
                     avatar: bytes = None,
                     bio: str = None,
@@ -441,6 +444,9 @@ class DBHandler:
 
         if auth_id:
             dbquery.auth_id = auth_id
+
+        if token_ttl:
+            dbquery.token_ttl = token_ttl
 
         if email:
             dbquery.email = email

--- a/mod/db/models.py
+++ b/mod/db/models.py
@@ -49,6 +49,7 @@ class UserConfig(orm.SQLObject):
     username = orm.StringCol(default=None)
     is_bot = orm.BoolCol(default=False)
     auth_id = orm.StringCol(default=None)
+    token_ttl = orm.IntCol(default=None)
     email = orm.StringCol(default=None)
     avatar = orm.BLOBCol(default=None)
     bio = orm.StringCol(default=None)

--- a/mod/error.py
+++ b/mod/error.py
@@ -46,6 +46,9 @@ class ServerStatus(IntEnum):
     CLIENT_CLOSED_REQUEST = (499,
                              'Client Closed Request',
                              'Full description: Client Closed Request')
+    VERSION_NOT_SUPPORTED = (505,
+                             'Version Not Supported',
+                             'Cannot fulfill request')
     UNKNOWN_ERROR = (520,
                      'Unknown Error',
                      'Full description: Unknown Error')

--- a/mod/protocol/mtp/api.py
+++ b/mod/protocol/mtp/api.py
@@ -27,7 +27,8 @@ from pydantic import BaseModel
 from pydantic import EmailStr
 
 # Version of MoreliaTalk Protocol
-VERSION: str = '1.0'
+VERSION = '1.0'
+REVISION = '17'
 
 # A description of the basic validation scheme for requests and responses.
 
@@ -62,6 +63,7 @@ class BaseUser(BaseModel):
     password: Optional[str] = None
     is_bot: Optional[bool] = None
     auth_id: Optional[str] = None
+    token_ttl: Optional[int] = None
     email: Optional[EmailStr] = None
 
 
@@ -112,6 +114,7 @@ class BaseVersion(BaseModel):
     """
 
     version: str
+    revision: Optional[str] = None
 
 
 class BaseValidator(BaseModel):

--- a/mod/protocol/mtp/worker.py
+++ b/mod/protocol/mtp/worker.py
@@ -116,7 +116,8 @@ class MTProtocol:
     def __init__(self,
                  request,
                  database: DBHandler):
-        self.jsonapi = api.VersionResponse(version=api.VERSION)
+        self.jsonapi = api.VersionResponse(version=api.VERSION,
+                                           revision=api.REVISION)
         self.get_time = int(time())
         self._db = database
 
@@ -283,13 +284,15 @@ class MTProtocol:
                               username=username,
                               is_bot=False,
                               auth_id=auth_id,
+                              token_ttl=self.get_time,
                               email=email,
                               avatar=None,
                               bio=None,
                               salt=generated.get_salt,
                               key=generated.get_key)
             user.append(api.UserResponse(uuid=uuid,
-                                         auth_id=auth_id))
+                                         auth_id=auth_id,
+                                         token_ttl=self.get_time))
             data = api.DataResponse(time=self.get_time,
                                     user=user)
             errors = MTPErrorResponse("CREATED")

--- a/tests/fixtures/valid.json
+++ b/tests/fixtures/valid.json
@@ -66,7 +66,8 @@
         "detail": "successfully"
         },
     "jsonapi": {
-        "version": "1.0"
+        "version": "1.0",
+        "revision": "17"
         },
     "meta": null
     }

--- a/tests/fixtures/valid.json
+++ b/tests/fixtures/valid.json
@@ -53,6 +53,7 @@
             "username": "Vasya",
             "is_bot": true,
             "auth_id": "4646hjgjhg64",
+            "token_ttl": 123456123456,
             "email": "querty@querty.com",
             "avatar": "fffdddddd",
             "bio": "My bio"

--- a/tests/fixtures/wrong.json
+++ b/tests/fixtures/wrong.json
@@ -65,7 +65,8 @@
         "detail": "successfully"
         },
     "jsonapi": {
-        "version": "1.0"
+        "version": "1.0",
+        "revision": "17"
         },
     "meta": null
     }

--- a/tests/test_protocol_mtp_api.py
+++ b/tests/test_protocol_mtp_api.py
@@ -54,7 +54,14 @@ class TestApiValidation(unittest.TestCase):
         del self.valid
 
     def test_validation_valid_json(self):
-        self.assertIsInstance(self.valid.dict(), dict)
+        result = self.valid.dict()
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['data']['user'][0]['token_ttl'],
+                         123456123456)
+        self.assertEqual(result['data']['message'][0]['client_id'],
+                         123456)
+        self.assertEqual(result['jsonapi']['version'], '1.0')
+        self.assertEqual(result['jsonapi']['revision'], '17')
 
     def test_validation_wrong_json(self):
         try:
@@ -99,11 +106,6 @@ class TestApiValidation(unittest.TestCase):
                              "field required")
         else:
             self.assertIsNone(self.test)
-
-    def test_api_jsonapi(self):
-        result = self.valid.dict()
-        self.assertEqual(result['jsonapi']['version'], '1.0')
-        self.assertEqual(result['jsonapi']['revision'], '17')
 
     def test_api_wrong_data_and_errors_in_request(self):
         try:

--- a/tests/test_protocol_mtp_api.py
+++ b/tests/test_protocol_mtp_api.py
@@ -65,8 +65,8 @@ class TestApiValidation(unittest.TestCase):
     def test_api_request(self):
         try:
             api.Request.parse_file(WRONG_REQUEST)
-        except Exception as ERROR:
-            result = ERROR.errors()
+        except Exception as err:
+            result = err.errors()
             self.assertEqual(result[0].get("msg"),
                              "str type expected")
             self.assertEqual(result[1].get("msg"),
@@ -85,8 +85,8 @@ class TestApiValidation(unittest.TestCase):
     def test_api_response(self):
         try:
             api.Response.parse_file(WRONG_RESPONSE)
-        except Exception as ERROR:
-            result = ERROR.errors()
+        except Exception as err:
+            result = err.errors()
             self.assertEqual(result[0].get("msg"),
                              "field required")
             self.assertEqual(result[1].get("msg"),
@@ -100,23 +100,16 @@ class TestApiValidation(unittest.TestCase):
         else:
             self.assertIsNone(self.test)
 
+    def test_api_jsonapi(self):
+        result = self.valid.dict()
+        self.assertEqual(result['jsonapi']['version'], '1.0')
+        self.assertEqual(result['jsonapi']['revision'], '17')
+
     def test_api_wrong_data_and_errors_in_request(self):
         try:
             api.Request.parse_file(WRONG_DATA_ERRORS)
-        except Exception as ERROR:
-            result = ERROR.errors()
-            self.assertEqual(result[0].get("msg"),
-                             "value is not a valid dict")
-            self.assertEqual(result[1].get("msg"),
-                             "value is not a valid dict")
-        else:
-            self.assertIsNone(self.test)
-
-    def test_api_wrong_data_and_errors_in_response(self):
-        try:
-            api.Response.parse_file(WRONG_DATA_ERRORS)
-        except Exception as ERROR:
-            result = ERROR.errors()
+        except Exception as err:
+            result = err.errors()
             self.assertEqual(result[0].get("msg"),
                              "value is not a valid dict")
             self.assertEqual(result[1].get("msg"),
@@ -127,20 +120,8 @@ class TestApiValidation(unittest.TestCase):
     def test_api_wrong_flow_and_message_in_request(self):
         try:
             api.Request.parse_file(WRONG_FLOW_MESSAGE)
-        except Exception as ERROR:
-            result = ERROR.errors()
-            self.assertEqual(result[0].get("msg"),
-                             "value is not a valid list")
-            self.assertEqual(result[1].get("msg"),
-                             "value is not a valid list")
-        else:
-            self.assertIsNone(self.test)
-
-    def test_api_wrong_flow_and_message_in_response(self):
-        try:
-            api.Response.parse_file(WRONG_FLOW_MESSAGE)
-        except Exception as ERROR:
-            result = ERROR.errors()
+        except Exception as err:
+            result = err.errors()
             self.assertEqual(result[0].get("msg"),
                              "value is not a valid list")
             self.assertEqual(result[1].get("msg"),

--- a/tests/test_protocol_mtp_worker.py
+++ b/tests/test_protocol_mtp_worker.py
@@ -170,6 +170,14 @@ class TestRegisterUser(unittest.TestCase):
         dbquery = self.db.get_user_by_login(login="login")
         self.assertEqual(dbquery.login, "login")
 
+    def test_token_ttl_write_to_database(self):
+        run_method = MTProtocol(self.test,
+                                self.db)
+        result = json.loads(run_method.get_response())
+        dbquery = self.db.get_user_by_login(login="login")
+        self.assertEqual(dbquery.token_ttl,
+                         result['data']['user'][0]['token_ttl'])
+
     def test_uuid_write_in_database(self):
         run_method = MTProtocol(self.test,
                                 self.db)
@@ -280,6 +288,13 @@ class TestGetUpdate(unittest.TestCase):
         result = json.loads(run_method.get_response())
         self.assertEqual(result["data"]["message"][1]["uuid"],
                          "112")
+
+    def test_check_client_id_in_result(self):
+        run_method = MTProtocol(self.test,
+                                self.db)
+        result = json.loads(run_method.get_response())
+        self.assertEqual(result["data"]["message"][1]["client_id"],
+                         None)
 
     def test_check_flow_in_result(self):
         run_method = MTProtocol(self.test,
@@ -465,10 +480,13 @@ class TestAllMessages(unittest.TestCase):
         self.assertEqual(result["data"]["flow"][0]["message_start"], 0)
 
     def test_check_message_in_database(self):
-        MTProtocol(self.test,
-                   self.db)
+        run_method = MTProtocol(self.test,
+                                self.db)
+        result = json.loads(run_method.get_response())
         dbquery = self.db.get_message_by_exact_time(666)
         self.assertEqual(dbquery[0].text, "Privet")
+        self.assertEqual(result['data']['message'][0]['client_id'],
+                         None)
 
     def test_wrong_message_volume(self):
         self.test.data.flow[0].message_end = 256
@@ -725,6 +743,9 @@ class TestDeleteUser(unittest.TestCase):
         result = json.loads(run_method.get_response())
         self.assertEqual(result["errors"]["status"],
                          "OK")
+        check_db = self.db.get_user_by_login(login='User deleted')
+        self.assertEqual(check_db.key, b'deleted')
+        self.assertEqual(check_db.salt, b'deleted')
 
     def test_wrong_login(self):
         self.test.data.user[0].login = "wrong_login"
@@ -933,6 +954,31 @@ class TestErrors(unittest.TestCase):
         self.assertEqual(result.status, "Bad Request")
         self.assertIsInstance(result.time, int)
         self.assertIsInstance(result.detail, str)
+
+
+class TestJsonapi(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        logger.remove()
+        cls.db = DBHandler(uri="sqlite:/:memory:")
+
+    def setUp(self):
+        self.db.create_table()
+        self.db.add_user(uuid="123456",
+                         login="login",
+                         password="password",
+                         auth_id="auth_id")
+        self.test = api.Request.parse_file(PING_PONG)
+
+    def tearDown(self):
+        self.db.delete_table()
+
+    def test_api_version_and_revision(self):
+        run_method = MTProtocol(self.test,
+                                self.db)
+        result = json.loads(run_method.get_response())
+        self.assertEqual(result['jsonapi']['version'], api.VERSION)
+        self.assertEqual(result['jsonapi']['revision'], api.REVISION)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Протокол MTP версии 1.0 обновлен до ревизии 17.

- в модель БД и в response (метод _register_user) добавлен token_ttl (пока просто сервер отправляет текущее время)
- в модуль валидации добавлеа костанта REVISION
- в схему валидации добавлены новые поля token_ttl и revision
- все генерируемые классом MTProtocol ответы содержат revision
- в класс ServerStatus добавлена описание ошибки с кодом 505 "Version Not Supported"
- в тесты добавлены проверки всех новых изменений

В остальной части реализация протокола в сервере соответствует 17 ревизии.

Closes #144
