### PR TITLE
Добавление линтера в actions и реализация функции проверки версии API протокола используемого клиентом

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,10 @@ jobs:
       run: |
         pipenv run coverage run -m unittest discover tests
 
+    - name: Linting code
+      run: |
+        pipenv run flake8 --config ./setup.cfg --show-source --statistics
+
     - name: Push report to coveralls.io
       env: 
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,9 @@ verify_ssl = true
 
 [dev-packages]
 flake8 = "*"
+flake8-import-order = "*"
+flake8-docstrings = "*"
+flake8-builtins = "*"
 pyflakes = "*"
 pycodestyle = "*"
 mccabe = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0628c267ce6c693fba4c09dc6e7555a5bf26b504ebfd00b0684590418b9cdd9e"
+            "sha256": "162da9afe5abdadfaa652138852366d791489638853dc87cef3dfac170c7bd45"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -72,19 +72,19 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45",
-                "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.11"
+            "version": "==2.0.12"
         },
         "click": {
             "hashes": [
-                "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3",
-                "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"
+                "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1",
+                "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.0.3"
+            "version": "==8.0.4"
         },
         "coverage": {
             "hashes": [
@@ -179,6 +179,22 @@
             "index": "pypi",
             "version": "==1.7.3"
         },
+        "flake8": {
+            "hashes": [
+                "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
+                "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==4.0.1"
+        },
+        "flake8-builtins": {
+            "hashes": [
+                "sha256:09998853b2405e98e61d2ff3027c47033adbdc17f9fe44ca58443d876eb00f3b",
+                "sha256:7706babee43879320376861897e5d1468e396a40b8918ed7bccf70e5f90b8687"
+            ],
+            "index": "pypi",
+            "version": "==1.5.3"
+        },
         "formencode": {
             "hashes": [
                 "sha256:8f2974112c2557839d5bae8b76490104c03830785d923abbdef148bf3f710035",
@@ -237,78 +253,56 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
-                "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
-                "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
-                "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194",
-                "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
-                "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
-                "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724",
-                "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74",
-                "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646",
-                "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
-                "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6",
-                "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a",
-                "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6",
-                "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad",
-                "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
-                "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38",
-                "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac",
-                "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
-                "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6",
-                "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047",
-                "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
-                "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
-                "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b",
-                "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
-                "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
-                "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a",
-                "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
-                "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1",
-                "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9",
-                "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864",
-                "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
-                "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee",
-                "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f",
-                "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
-                "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
-                "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
-                "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
-                "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b",
-                "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
-                "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86",
-                "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6",
-                "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
-                "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
-                "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
-                "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28",
-                "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e",
-                "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
-                "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
-                "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f",
-                "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d",
-                "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
-                "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
-                "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145",
-                "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
-                "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c",
-                "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1",
-                "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a",
-                "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207",
-                "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
-                "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53",
-                "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd",
-                "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134",
-                "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85",
-                "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9",
-                "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
-                "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
-                "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
-                "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
-                "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
+                "sha256:023af8c54fe63530545f70dd2a2a7eed18d07a9a77b94e8bf1e2ff7f252db9a3",
+                "sha256:09c86c9643cceb1d87ca08cdc30160d1b7ab49a8a21564868921959bd16441b8",
+                "sha256:142119fb14a1ef6d758912b25c4e803c3ff66920635c44078666fe7cc3f8f759",
+                "sha256:1d1fb9b2eec3c9714dd936860850300b51dbaa37404209c8d4cb66547884b7ed",
+                "sha256:204730fd5fe2fe3b1e9ccadb2bd18ba8712b111dcabce185af0b3b5285a7c989",
+                "sha256:24c3be29abb6b34052fd26fc7a8e0a49b1ee9d282e3665e8ad09a0a68faee5b3",
+                "sha256:290b02bab3c9e216da57c1d11d2ba73a9f73a614bbdcc027d299a60cdfabb11a",
+                "sha256:3028252424c72b2602a323f70fbf50aa80a5d3aa616ea6add4ba21ae9cc9da4c",
+                "sha256:30c653fde75a6e5eb814d2a0a89378f83d1d3f502ab710904ee585c38888816c",
+                "sha256:3cace1837bc84e63b3fd2dfce37f08f8c18aeb81ef5cf6bb9b51f625cb4e6cd8",
+                "sha256:4056f752015dfa9828dce3140dbadd543b555afb3252507348c493def166d454",
+                "sha256:454ffc1cbb75227d15667c09f164a0099159da0c1f3d2636aa648f12675491ad",
+                "sha256:598b65d74615c021423bd45c2bc5e9b59539c875a9bdb7e5f2a6b92dfcfc268d",
+                "sha256:599941da468f2cf22bf90a84f6e2a65524e87be2fce844f96f2dd9a6c9d1e635",
+                "sha256:5ddea4c352a488b5e1069069f2f501006b1a4362cb906bee9a193ef1245a7a61",
+                "sha256:62c0285e91414f5c8f621a17b69fc0088394ccdaa961ef469e833dbff64bd5ea",
+                "sha256:679cbb78914ab212c49c67ba2c7396dc599a8479de51b9a87b174700abd9ea49",
+                "sha256:6e104c0c2b4cd765b4e83909cde7ec61a1e313f8a75775897db321450e928cce",
+                "sha256:736895a020e31b428b3382a7887bfea96102c529530299f426bf2e636aacec9e",
+                "sha256:75bb36f134883fdbe13d8e63b8675f5f12b80bb6627f7714c7d6c5becf22719f",
+                "sha256:7d2f5d97fcbd004c03df8d8fe2b973fe2b14e7bfeb2cfa012eaa8759ce9a762f",
+                "sha256:80beaf63ddfbc64a0452b841d8036ca0611e049650e20afcb882f5d3c266d65f",
+                "sha256:84ad5e29bf8bab3ad70fd707d3c05524862bddc54dc040982b0dbcff36481de7",
+                "sha256:8da5924cb1f9064589767b0f3fc39d03e3d0fb5aa29e0cb21d43106519bd624a",
+                "sha256:961eb86e5be7d0973789f30ebcf6caab60b844203f4396ece27310295a6082c7",
+                "sha256:96de1932237abe0a13ba68b63e94113678c379dca45afa040a17b6e1ad7ed076",
+                "sha256:a0a0abef2ca47b33fb615b491ce31b055ef2430de52c5b3fb19a4042dbc5cadb",
+                "sha256:b2a5a856019d2833c56a3dcac1b80fe795c95f401818ea963594b345929dffa7",
+                "sha256:b8811d48078d1cf2a6863dafb896e68406c5f513048451cd2ded0473133473c7",
+                "sha256:c532d5ab79be0199fa2658e24a02fce8542df196e60665dd322409a03db6a52c",
+                "sha256:d3b64c65328cb4cd252c94f83e66e3d7acf8891e60ebf588d7b493a55a1dbf26",
+                "sha256:d4e702eea4a2903441f2735799d217f4ac1b55f7d8ad96ab7d4e25417cb0827c",
+                "sha256:d5653619b3eb5cbd35bfba3c12d575db2a74d15e0e1c08bf1db788069d410ce8",
+                "sha256:d66624f04de4af8bbf1c7f21cc06649c1c69a7f84109179add573ce35e46d448",
+                "sha256:e67ec74fada3841b8c5f4c4f197bea916025cb9aa3fe5abf7d52b655d042f956",
+                "sha256:e6f7f3f41faffaea6596da86ecc2389672fa949bd035251eab26dc6697451d05",
+                "sha256:f02cf7221d5cd915d7fa58ab64f7ee6dd0f6cddbb48683debf5d04ae9b1c2cc1",
+                "sha256:f0eddfcabd6936558ec020130f932d479930581171368fd728efcfb6ef0dd357",
+                "sha256:fabbe18087c3d33c5824cb145ffca52eccd053061df1d79d4b66dafa5ad2a5ea",
+                "sha256:fc3150f85e2dbcf99e65238c842d1cfe69d3e7649b19864c1cc043213d9cd730"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.0.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.1.0"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
         },
         "packaging": {
             "hashes": [
@@ -324,6 +318,14 @@
                 "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04"
             ],
             "version": "==1.7.4"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
+                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.8.0"
         },
         "pydantic": {
             "hashes": [
@@ -372,6 +374,14 @@
                 "sha256:5be4a8be12805ef7d712dd9a93284fb8bc53f309867e573f653a72e5fd10e433"
             ],
             "version": "==2.0.5"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
+                "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.0"
         },
         "pygments": {
             "hashes": [
@@ -524,11 +534,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e",
-                "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"
+                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
+                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==4.0.1"
+            "version": "==4.1.1"
         },
         "urllib3": {
             "hashes": [
@@ -627,11 +637,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45",
-                "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.11"
+            "version": "==2.0.12"
         },
         "coverage": {
             "hashes": [
@@ -705,8 +715,24 @@
                 "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
                 "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==4.0.1"
+        },
+        "flake8-docstrings": {
+            "hashes": [
+                "sha256:99cac583d6c7e32dd28bbfbef120a7c0d1b6dde4adb5a9fd441c4227a6534bde",
+                "sha256:9fe7c6a306064af8e62a055c2f61e9eb1da55f84bb39caef2b84ce53708ac34b"
+            ],
+            "index": "pypi",
+            "version": "==1.6.0"
+        },
+        "flake8-import-order": {
+            "hashes": [
+                "sha256:90a80e46886259b9c396b578d75c749801a41ee969a235e163cfe1be7afd2543",
+                "sha256:a28dc39545ea4606c1ac3c24e9d05c849c6e5444a50fb7e9cdd430fc94de6e92"
+            ],
+            "index": "pypi",
+            "version": "==0.18.1"
         },
         "idna": {
             "hashes": [
@@ -721,7 +747,6 @@
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
-            "index": "pypi",
             "version": "==0.6.1"
         },
         "pycodestyle": {
@@ -729,15 +754,23 @@
                 "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
                 "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.8.0"
+        },
+        "pydocstyle": {
+            "hashes": [
+                "sha256:1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc",
+                "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==6.1.1"
         },
         "pyflakes": {
             "hashes": [
                 "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
                 "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.0"
         },
         "requests": {
@@ -747,6 +780,21 @@
             ],
             "index": "pypi",
             "version": "==2.27.1"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:2347b2b432c891a863acadca2da9ac101eae6169b1d3dfee2ec605ecd50dbfe5",
+                "sha256:e4f30b9f84e5ab3decf945113119649fec09c1fc3507c6ebffec75646c56e62b"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==60.9.3"
+        },
+        "snowballstemmer": {
+            "hashes": [
+                "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1",
+                "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"
+            ],
+            "version": "==2.2.0"
         },
         "urllib3": {
             "hashes": [

--- a/admin/admin.py
+++ b/admin/admin.py
@@ -1,35 +1,38 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
+
+from pathlib import Path
+
 from fastapi import Depends
 from fastapi.applications import FastAPI
 from fastapi.requests import Request
 from fastapi.templating import Jinja2Templates
-from pathlib import Path
 from starlette.responses import RedirectResponse
 
-from mod.db.dbhandler import DBHandler
 from mod.config.config import ConfigHandler
+from mod.db.dbhandler import DBHandler
+from . import control as manage
 from . import login
 from . import logs
-from . import control as manage
+
 
 app = FastAPI()
 
@@ -49,74 +52,78 @@ db_connect = DBHandler(config_option.uri)
 def not_login_exception_handler(request: Request,
                                 exc: login.NotAuthenticatedException):
     """
-    Catches exception login.NotAuthenticatedException and redirects the user to the login page("/admin/login/")
+    Catches exception NotAuthenticatedException and redirects to login page.
 
     Args:
         request(Request): request to the server
-        exc(login.NotAuthenticatedException): catchable user authentication error
+        exc(login.NotAuthenticatedException): catchable user authentication
+            error
 
     Returns:
         (RedirectResponse): redirect response to /admin/login
     """
+
     return RedirectResponse(url="/admin/login")
 
 
 @app.get("/login")
 def login_admin(request: Request):
     """
-    The function is triggered when a request is received for the /login address
-    and returns a response generated from login.html
+    Triggered when a request is received for the /login address.
+    Return a response generated from login.html
 
     Args:
         request(Request): request to the server
 
     Returns:
-        (templates.TemplateResponse): response generated from login.html template
-
+        (templates.TemplateResponse): response generated from login.html
+            template
     """
-    return templates.TemplateResponse("login.html", {
-                                        "request": request
-                                        })
+
+    return templates.TemplateResponse("login.html",
+                                      {"request": request})
 
 
 @app.get("/")
 def index_admin(request: Request,
                 user=Depends(login.login_manager)):
     """
-    Returns a response with the main page of the admin panel
+    Returns a response with the main page of the admin panel.
 
     Args:
         request(Request): request to the server
         user: user authentication check
 
     Returns:
-        (templates.TemplateResponse): response generated from index_admin.html template
+        (templates.TemplateResponse): response generated from index_admin.html
+        qtemplate
     """
-    return templates.TemplateResponse("index_admin.html", {
-                                        "request": request
-                                        })
+
+    return templates.TemplateResponse("index_admin.html",
+                                      {"request": request})
 
 
 @app.get("/status")
 def status_admin(request: Request,
                  user=Depends(login.login_manager)):
     """
-        Returns a response with the status page of the admin panel
+    Returns a response with the status page of the admin panel.
 
-        Args:
-            request(Request): request to the server
-            user: user authentication check
+    Args:
+        request(Request): request to the server
+        user: user authentication check
 
-        Returns:
-            (templates.TemplateResponse): response generated from status_admin.html template
-        """
+    Returns:
+        (templates.TemplateResponse): response generated from
+            status_admin.html template
+    """
+
     dbquery = db_connect.get_table_count()
     return templates.TemplateResponse("status_admin.html",
                                       {"request": request,
                                        "Messages_count": dbquery.message_count,
                                        "Flows_count": dbquery.flow_count,
-                                       "Users_count": dbquery.user_count
-                                       })
+                                       "Users_count": dbquery.user_count})
 
 
 # TODO Полностью доделать(на данный момент управление сервером не работает)
@@ -125,35 +132,37 @@ def status_admin(request: Request,
 def manage_admin(request: Request,
                  user=Depends(login.login_manager)):
     """
-        Returns a response with the mange page of the admin panel
+    Returns a response with the mange page of the admin panel.
 
-        Args:
-            request(Request): request to the server
-            user: user authentication check
+    Args:
+        request(Request): request to the server
+        user: user authentication check
 
-        Returns:
-            (templates.TemplateResponse): response generated from manage_admin.html template
+    Returns:
+        (templates.TemplateResponse): response generated from
+            manage_admin.html template
     """
+
     dbquery = db_connect.get_all_user()
-    return templates.TemplateResponse("manage_admin.html", {
-                                        "request": request,
-                                        "users": dbquery.count()
-                                        })
+    return templates.TemplateResponse("manage_admin.html",
+                                      {"request": request,
+                                       "users": dbquery.count()})
 
 
 @app.get("/logs")
 def manage_logs(request: Request,
                 user=Depends(login.login_manager)):
     """
-        Returns a response with the logs view page of the admin panel
+    Returns a response with the logs view page of the admin panel.
 
-        Args:
-            request(Request): request to the server
-            user: user authentication check
+    Args:
+        request(Request): request to the server
+        user: user authentication check
 
-        Returns:
-            (templates.TemplateResponse): response generated from logs_admin.html template
+    Returns:
+        (templates.TemplateResponse): response generated from logs_admin.html
+            template
     """
-    return templates.TemplateResponse("logs_admin.html", {
-                                        "request": request
-                                        })
+
+    return templates.TemplateResponse("logs_admin.html",
+                                      {"request": request})

--- a/admin/control.py
+++ b/admin/control.py
@@ -1,23 +1,24 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
+
 from uuid import uuid4
 
 from fastapi import APIRouter
@@ -25,8 +26,9 @@ from fastapi import Form
 from starlette.requests import Request
 from starlette.responses import HTMLResponse
 
-from mod.db.dbhandler import DBHandler
 from mod.config.config import ConfigHandler
+from mod.db.dbhandler import DBHandler
+
 
 config = ConfigHandler()
 config_option = config.read()
@@ -41,16 +43,17 @@ db_connect = DBHandler(config_option.uri)
 def delete_user(request: Request,
                 uuid: str = Form(...)):
     """
-        The function receives the request and admin uuid, delete admin user,
-        and returns a response, redirecting to the main page of the admin panel
+    Delete admin user.
+    After returns a response and redirecting to the main page of admin panel.
 
-        Args:
-            request(Request): request for server
-            uuid(str): uuid admin user
+    Args:
+        request(Request): request for server
+        uuid(str): uuid admin user
 
-        Returns:
-            (HTMLResponse): response redirecting to the main admin page
+    Returns:
+        (HTMLResponse): response redirecting to the main admin page
     """
+
     fake_uuid = str(uuid4().int)
 
     db_connect.update_user(uuid=uuid,

--- a/admin/login.py
+++ b/admin/login.py
@@ -1,33 +1,34 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
+
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import Request
-from fastapi_login import LoginManager
 from fastapi.security import OAuth2PasswordRequestForm
+from fastapi_login import LoginManager
 from starlette.responses import HTMLResponse
 
 from mod import lib
-from mod.db.dbhandler import DBHandler
 from mod.config.config import ConfigHandler
+from mod.db.dbhandler import DBHandler
 
 
 config = ConfigHandler()
@@ -40,9 +41,8 @@ router = APIRouter()
 
 class NotAuthenticatedException(Exception):
     """
-        An exception occurs when the user's authorization data is missing or incorrect
+    Occurs when the user's authorization data is missing or incorrect.
     """
-    pass
 
 
 login_manager = LoginManager(config_option.secret_key,
@@ -56,14 +56,15 @@ login_manager.not_authenticated_exception = NotAuthenticatedException
 @login_manager.user_loader()
 def get_admin_user_data(username: str):
     """
-    The function of requesting data from the database and checking it against the username, if there is valid data, it returns it
+    Requesting data from the database and checking it against the username.
 
     Args:
         username(str): username admin user
 
     Returns:
-        (SQLObject) - admin user data from db
+        (SQLObject): admin user data from db
     """
+
     data = db_connect.get_admin_by_name(username=username)
     if data.count():
         return data[0]
@@ -72,9 +73,7 @@ def get_admin_user_data(username: str):
 @router.post("/login/token")
 def login_token(data: OAuth2PasswordRequestForm = Depends()):
     """
-    The function receives the data
-    and returns a response that contains the admin token for the user,
-    valid for 15 minutes
+    Returns a response that contains the admin token, valid for 15 minutes.
 
     Args:
         data(OAuth2PasswordRequestForm): login data
@@ -114,15 +113,15 @@ def login_token(data: OAuth2PasswordRequestForm = Depends()):
 @router.post("/login/logout")
 def logout(request: Request):
     """
-        The function receives the request
-        and returns a response that contains the invalid admin token
+    Returns a response that contains the invalid admin token.
 
-        Args:
-            request(Request): request for server
+    Args:
+        request(Request): request for server
 
-        Returns:
-            (HTMLResponse): response with cookies embedded in it
+    Returns:
+        (HTMLResponse): response with cookies embedded in it
     """
+
     incorrect_token = "MoreliaTalk"
 
     response = HTMLResponse("""<script>

--- a/admin/logs.py
+++ b/admin/logs.py
@@ -1,27 +1,28 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from fastapi import APIRouter
 from fastapi import Depends
 from starlette.requests import Request
+
 from . import login
 
 router = APIRouter()
@@ -33,24 +34,26 @@ log_string = str()
 def get_logs(request: Request,
              user=Depends(login.login_manager)):
     """
-        Returns a dict with server logs
+    Returns a dict with server logs.
 
-        Args:
-            request(Request): request to the server
-            user: user authentication check
+    Args:
+        request(Request): request to the server
+        user: user authentication check
 
-        Returns:
-            (dict)
+    Returns:
+        (dict)
     """
+
     return {"logs": log_string}
 
 
 def loguru_handler(log: str):
     """
-        Function collects server logs
+    Function collects server logs.
 
-        Args:
-            log(str): new log string
+    Args:
+        log(str): new log string
     """
+
     global log_string
     log_string += log

--- a/client.py
+++ b/client.py
@@ -1,40 +1,31 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
-# ************** Standart module *********************
 import json
 from typing import Union
-# ************** Standart module end *****************
 
-
-# ************** External module *********************
-import websocket
-# ************** External module end *****************
-
-
-# ************** Logging beginning *******************
 from loguru import logger
-from mod.logging import add_logging
-# ************** Logging end *************************
+import websocket
 
+from mod.logging import add_logging
 
 # logger on INFO
 add_logging(20)
@@ -52,78 +43,53 @@ auth_id = "6989f3f8d1b9c2fdf0bb858a5953d07c"
 
 GET_UPDATE = {
     "type": "get_update",
-    "data": {
-        "time": 111,
-        "user": [{
-            "uuid": uuid,
-            "auth_id": auth_id,
-            }],
-        "meta": None
-        },
-    "jsonapi": {
-        "version": "1.0"
-        },
+    "data": {"time": 111,
+             "user": [{"uuid": uuid,
+                       "auth_id": auth_id}],
+             "meta": None},
+    "jsonapi": {"version": "1.0"},
     "meta": None
-    }
+}
 
 AUTH = {
     "type": "authentication",
-    "data": {
-        "user": [{
-            "password": user_password,
-            "login": user_login
-            }],
-        "meta": None
-        },
-    "jsonapi": {
-        "version": "1.0"
-        },
+    "data": {"user": [{"password": user_password,
+                       "login": user_login}],
+             "meta": None},
+    "jsonapi": {"version": "1.0"},
     "meta": None
-    }
+}
 
 ADD_FLOW = {
     "type": "add_flow",
-    "data": {
-        "flow": [{
-            "uuid": None,
-            "type": "group",
-            "title": "title",
-            "info": "info",
-            "owner": uuid,
-            "users": [uuid]
-            }],
-        "user": [{
-            "uuid": uuid,
-            "auth_id": "auth_id",
-            }],
-        "meta": None
-        },
-    "jsonapi": {
-        "version": "1.0"
-        },
+    "data": {"flow": [{"uuid": None,
+                       "type": "group",
+                       "title": "title",
+                       "info": "info",
+                       "owner": uuid,
+                       "users": [uuid]}],
+             "user": [{"uuid": uuid,
+                       "auth_id": "auth_id"}],
+             "meta": None},
+    "jsonapi": {"version": "1.0"},
     "meta": None
-    }
+}
 
 ALL_FLOW = {
     "type": "all_flow",
-    "data": {
-        "user": [{
-            "uuid": uuid,
-            "auth_id": "auth_id"
-            }],
-        "meta": None
-        },
-    "jsonapi": {
-        "version": "1.0"
-        },
+    "data": {"user": [{"uuid": uuid,
+                       "auth_id": "auth_id"}],
+             "meta": None},
+    "jsonapi": {"version": "1.0"},
     "meta": None
-    }
+}
 
 
 # Chat websocket
-def send_message(message: Union[dict, str] = AUTH, 
+def send_message(message: Union[dict, str] = AUTH,
                  uri: str = LOCALHOST) -> bytes:
-    """Sending a message via websockets, with a response
+    """
+    Sending a message via websockets, with a response.
 
     Args:
         message ([dict], required): message.

--- a/debug_server.py
+++ b/debug_server.py
@@ -1,21 +1,22 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import uvicorn

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -58,6 +58,32 @@ Cloning a repository
 5. If using GitHub Desktop, select ``Clone repository...`` from ``File`` menu and follow instructions.
 
 
+Running before create pool-request
+__________________________________
+
+Before create pool-request you must be perform two step:
+
+1. Running ``flake8`` for checking code:
+
+::
+
+ pipenv run flake8 --config ./setup.cfg --show-source --statistics --output-file ./log/flake8.log
+
+``--config ./setup.cfg`` - path to flake8 settings
+
+``--show-source`` - show the source generate each error or warning
+
+``--statistics`` - count errors and warnings
+
+``--output-file ./log/flake8.log`` - path to file where flake8 saved all information about occurrences errors and warnings
+
+2. Running unittest for testing code (``tests`` it's a directory contains all test for project):
+
+::
+
+ pipenv run coverage run -m unittest discover tests
+
+
 Creating a pool-request
 -----------------------
 

--- a/example_config.ini
+++ b/example_config.ini
@@ -52,6 +52,12 @@ MESSAGES = 100
 USERS = 100
 
 
+[API_VERSION]
+# Maximum and minimum version of API which server supported
+MAX = 1.9
+MIN = 1.0
+
+
 [SUPERUSER]
 UUID = 123456789
 USERNAME = superuser

--- a/example_config.ini
+++ b/example_config.ini
@@ -54,8 +54,8 @@ USERS = 100
 
 [API_VERSION]
 # Maximum and minimum version of API which server supported
-MAX = 1.9
-MIN = 1.0
+MAX_VERSION = 1.9
+MIN_VERSION = 1.0
 
 
 [SUPERUSER]

--- a/manage.py
+++ b/manage.py
@@ -1,50 +1,58 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
-from time import time
 from time import process_time
+from time import time
 from uuid import uuid4
 
 import click
 
 from mod import lib
-from mod.db import dbhandler
-from mod.db.dbhandler import DatabaseWriteError
-from mod.db.dbhandler import DatabaseReadError
-from mod.db.dbhandler import DatabaseAccessError
 from mod.config.config import ConfigHandler
+from mod.db.dbhandler import DatabaseAccessError
+from mod.db.dbhandler import DatabaseReadError
+from mod.db.dbhandler import DatabaseWriteError
+from mod.db.dbhandler import DBHandler
 
 
 config = ConfigHandler()
 config_option = config.read()
 
+
 @click.group()
 def cli():
+    """
+    Group all command.
+    """
     pass
 
 
 @cli.command("db-create", help="Create all table with all data")
 def db_create():
+    """
+    Create database, and create all table which contain in models.
+    """
+
     start_time = process_time()
-    db = dbhandler.DBHandler(uri=config_option.uri)
+    db = DBHandler(uri=config_option.uri)
     db.create_table()
     click.echo(f'Table is created at: '
                f'{process_time() - start_time} sec.')
@@ -52,8 +60,13 @@ def db_create():
 
 @cli.command("db-delete", help="Delete all table with all data")
 def db_delete():
+    """
+    Delete all tables which contains data.
+    This function not delete database file.
+    """
+
     start_time = process_time()
-    db = dbhandler.DBHandler(uri=config_option.uri)
+    db = DBHandler(uri=config_option.uri)
     db.delete_table()
     click.echo(f'Table is deleted at: '
                f'{process_time() - start_time} sec.')
@@ -61,9 +74,13 @@ def db_delete():
 
 @cli.command("superuser-create", help="Create superuser in database")
 def create_superuser():
-    db = dbhandler.DBHandler(uri=config_option.uri)
+    """
+    Creating user who has all rights of management server with admin panel.
+    """
+
+    db = DBHandler(uri=config_option.uri)
     user_uuid = str(123456789)
-    hash_password = SUPERUSER.get('hash_password')
+    hash_password = 'hash_password'
     try:
         db.add_user(uuid=user_uuid,
                     login="login",
@@ -79,7 +96,11 @@ def create_superuser():
 
 @cli.command("flow-create", help="Create flow type group in database")
 def create_flow():
-    db = dbhandler.DBHandler(uri=config_option.uri)
+    """
+    Creating and adding test flow (group) in database.
+    """
+
+    db = DBHandler(uri=config_option.uri)
     user_uuid = str(123456789)
     try:
         new_user = db.get_user_by_uuid(uuid=user_uuid)
@@ -101,8 +122,17 @@ def create_flow():
 @cli.command("admin-create", help="Create user in admin panel")
 @click.option("--username", help="username admin")
 @click.option("--password", help="password admin")
-def admin_create_user(username, password):
-    db = dbhandler.DBHandler(uri=config_option.uri)
+def admin_create_user(username,
+                      password):
+    """
+    Create Admin user to management server with admin panel.
+
+    Args:
+        username: name of admin user
+        password: password of admin user
+    """
+
+    db = DBHandler(uri=config_option.uri)
 
     generator = lib.Hash(password,
                          str(uuid4().hex),

--- a/mod/__init__.py
+++ b/mod/__init__.py
@@ -1,22 +1,22 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
 __all__ = ["controller", "error", "lib", "logging", "db", "protocol"]

--- a/mod/config/__init__.py
+++ b/mod/config/__init__.py
@@ -1,21 +1,22 @@
 """
-    Copyright (c) 2022 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2022 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
+
 __all___ = ["config"]

--- a/mod/config/config.py
+++ b/mod/config/config.py
@@ -1,33 +1,32 @@
 """
-    Copyright (c) 2021 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2021 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
-import os
-
+from collections import namedtuple
 from configparser import ConfigParser
 from configparser import Interpolation
+import os
 from pathlib import Path
 from pathlib import PurePath
 from time import time
 from typing import Any
-from collections import namedtuple
 
 from loguru import logger
 
@@ -36,52 +35,54 @@ from mod.config.validator import ConfigModel
 
 class NameConfigError(Exception):
     """
-    Occurs when there is an error in the name of the file with the settings
-    or there is no such file at all.
+    Occurs when there is an error in the name of the file.
+    For example there is no such file at all.
     """
 
 
 class BackupConfigError(OSError):
     """
-    Occurs when a backup of a file is impossible, for example, you can't read
-    the original settings file, or you don't have written access to
-    the directory.
+    Occurs when a backup of a file is impossible.
+    For example, you can't read the original settings file,
+    or you don't have written access to the directory.
     """
 
 
 class OperationConfigError(Exception):
     """
-    Occurs when an option written to a configuration file is duplicated or
-    when a configuration file parsing error has occurred.
+    Occurs when an option written to a configuration file is duplicated.
+    Or when a configuration file parsing error has occurred.
     """
 
 
 class AccessConfigError(OSError):
     """
-    Occurs when writing to the configuration file failed because of the lack
-    of write permissions to the file or the lack of the file itself.
+    Occurs when writing to the configuration file failed.
+    Because of the lack of write permissions to the file
+    or the lack of the file itself.
     """
 
 
 class RebuildConfigError(Exception):
     """
-    Occurs when the configuration file could not be restored because of the
-    lack of permissions to write to the file or the absence of the file itself.
+    Occurs when the configuration file could not be restored.
+    Because of the lack of permissions to write to the file
+    or the absence of the file itself.
     """
 
 
 class CopyConfigError(Exception):
     """
-    Occurs when it was not possible to copy the old configuration file to
-    the new one line by line because there are no write permissions to
-    the file or because the file itself is missing.
+    Occurs when it was not possible to copy old configuration file to new one.
+    Because there are no write permissions to the file or because the file
+    itself is missing.
     """
 
 
 class ConfigHandler:
     """
-    Main module for work with settings contains in configuration file,
-    by default it is config.ini
+    Main module for work with settings contains in configuration file.
+    By default, it is config.ini
 
     Args:
         name (str): name of configuration file.
@@ -90,7 +91,8 @@ class ConfigHandler:
             by default it is BasicInterpolation. None can be used to turn off
             interpolation completely, ExtendedInterpolation provides a more
             advanced variant inspired by zc.buildout. More on the subject in
-            the dedicated documentation section for build-ins configparser modules.
+            the dedicated documentation section for build-ins configparser
+            modules.
     """
 
     def __init__(self,
@@ -106,8 +108,8 @@ class ConfigHandler:
                           name: str,
                           directory: Any) -> None:
         """
-        Starts the process of finding a configuration file and configures
-        the configparser module to work with it.
+        Starts the process of finding a configuration file.
+        Configures configparser module to work with it.
 
         Args:
             name (str): name of configuration file
@@ -163,8 +165,7 @@ class ConfigHandler:
 
     def __repr__(self) -> str:
         """
-        Return string which contains name of created class and parameters send
-        to class object when is created.
+        Return name of created class and parameters send to class object.
 
         Returns:
             (str): Class __name__ with: config_name=config.ini,
@@ -212,8 +213,8 @@ class ConfigHandler:
 
     def _backup_config_file(self) -> tuple[str, PurePath]:
         """
-        Creating a copy of the configuration file with the addition
-        at the end of the name: BAK + time in seconds.
+        Creating a backup copy of the configuration file.
+        Also, addition at the end of the name this string: BAK + Unix time.
 
         Returns:
             tuple(str, PurePath): Tuple contains string 'Backup config.ini
@@ -264,8 +265,8 @@ class ConfigHandler:
                         new_config: str = 'config.ini',
                         directory: str = 'tests/fixtures') -> str:
         """
-        Restoring the configuration file.  Copying lines from
-        example_config.ini to config.ini
+        Restoring the configuration file.
+        Copying lines from example_config.ini to config.ini file.
 
         Args:
             orig_config (str): default 'example_config.ini'
@@ -294,8 +295,7 @@ class ConfigHandler:
     @property
     def root_directory(self) -> str | None:
         """
-        Parameter that reports name of the root directory that is set for
-        initial search of the configuration file.
+        Reports name of directory that is set for initial search config file.
 
         Returns:
             (str, None): name of directory, if None that mean root directory
@@ -351,8 +351,9 @@ class ConfigHandler:
 
     def read(self) -> namedtuple:
         """
-        Read settings from a configuration file, validate them,
-        and generate a named tuple with key=value parameters.
+        Read settings from a configuration file.
+        Also, validate settings and generate a named tuple with key=value
+        parameters.
 
         Returns:
             Config (namedtuple): with key=value

--- a/mod/config/validator.py
+++ b/mod/config/validator.py
@@ -1,32 +1,30 @@
 """
-    Copyright (c) 2022 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2022 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from pydantic import BaseModel
-from typing import Any
 
 
 class ConfigModel(BaseModel):
     """
-    Describe the validation scheme for config.ini file which contain all
-    server settings.
+    Validation scheme for configuration file.
     """
 
     class Config:

--- a/mod/config/validator.py
+++ b/mod/config/validator.py
@@ -58,5 +58,8 @@ class ConfigModel(BaseModel):
     # Server limit section
     messages: int
     users: int
+    # API version section
+    max_version: str
+    min_version: str
     # Admin section
     secret_key: str

--- a/mod/controller.py
+++ b/mod/controller.py
@@ -1,34 +1,34 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import json
 
 from mod.db.dbhandler import DBHandler
-from mod.protocol.mtp.worker import MTProtocol
 from mod.protocol.matrix.worker import MatrixProtocol
+from mod.protocol.mtp.worker import MTProtocol
 
 
 class MainHandler:
     """
-    According to the selected protocol sends a request to the handler
+    According to the selected protocol sends a request to the handler.
 
     Args:
         request (object): JSON request from websocket client
@@ -51,18 +51,17 @@ class MainHandler:
 
     def get_response(self):
         """
-        Returns the result of the request processing depending on the protocol
+        Returns result of request processing depending on the protocol.
 
         Returns:
-                (json)
+            (json)
         """
 
         return self.response
 
     def _mtp_handler(self) -> json:
         """
-        Returns the result of the get_response method of the class handling
-        the MTP protocol
+        Returns result get_response method of the class handling MTP protocol.
 
         Returns:
             (json):
@@ -74,8 +73,7 @@ class MainHandler:
 
     def _matrix_handler(self) -> json:
         """
-        Returns the result of the get_response method of the class handling
-        the Matrix protocol
+        Returns result get_response method of class handling Matrix protocol.
 
         Returns:
             (json):

--- a/mod/controller.py
+++ b/mod/controller.py
@@ -45,9 +45,9 @@ class MainHandler:
         self.protocol = protocol
 
         if protocol == 'matrix':
-            self.response = self.matrix_handler()
+            self.response = self._matrix_handler()
         else:
-            self.response = self.mtp_handler()
+            self.response = self._mtp_handler()
 
     def get_response(self):
         """
@@ -59,7 +59,7 @@ class MainHandler:
 
         return self.response
 
-    def mtp_handler(self) -> json:
+    def _mtp_handler(self) -> json:
         """
         Returns the result of the get_response method of the class handling
         the MTP protocol
@@ -72,7 +72,7 @@ class MainHandler:
                             self.database).get_response()
         return result
 
-    def matrix_handler(self) -> json:
+    def _matrix_handler(self) -> json:
         """
         Returns the result of the get_response method of the class handling
         the Matrix protocol

--- a/mod/db/__init__.py
+++ b/mod/db/__init__.py
@@ -1,22 +1,22 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
 __all__ = ['dbhandler']

--- a/mod/db/dbhandler.py
+++ b/mod/db/dbhandler.py
@@ -1,42 +1,42 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
-import sys
-import inspect
 from collections import namedtuple
+import inspect
+import sys
 
 import sqlobject as orm
-from sqlobject.sqlbuilder import AND
+from sqlobject import SQLObject
 from sqlobject.main import SQLObjectIntegrityError
 from sqlobject.main import SQLObjectNotFound
+from sqlobject.sqlbuilder import AND
 from sqlobject.sresults import SelectResults
-from sqlobject import SQLObject
 
 from mod.db import models
 
 
 class DatabaseReadError(SQLObjectNotFound):
     """
-    Occurs when there is no table in the database, there was a problem at
-    the stage of reading from database.
+    Occurs when there is no table in the database.
+    There was a problem at the stage of reading from database.
     """
 
 
@@ -108,8 +108,7 @@ class DBHandler:
 
     def __repr__(self) -> str:
         """
-        Return string which contains name of created class and parameters send
-        to class object when is created.
+        Return name class name and parameters send to class when is created.
 
         Returns:
             (str): Class __name__: debug=, logger=, loglevel=
@@ -122,7 +121,7 @@ class DBHandler:
 
     def __search_db_in_models(self) -> tuple:
         """
-        Search all class name which contains in models.py
+        Search all class name which contains in models.
 
         Returns:
             (tuple): name of table
@@ -135,7 +134,7 @@ class DBHandler:
 
     def create_table(self) -> None:
         """
-        Create all table which contains in models.py
+        Create all table which contains in models.
 
         Returns:
             (None):
@@ -149,7 +148,7 @@ class DBHandler:
 
     def delete_table(self) -> None:
         """
-        Delete all table which contains in models.py
+        Delete all table which contains in models.
 
         Returns:
             (None):
@@ -353,8 +352,8 @@ class DBHandler:
                  salt: bytes = None,
                  key: bytes = None) -> SQLObject:
         """
-        Added new user to the UserConfig table,
-        if salt or key is None then used blank string converted to bytes.
+        Added new user to the UserConfig table.
+        If salt or key is None then used blank string converted to bytes.
 
         Args:
             uuid (str): unique user identify number
@@ -364,6 +363,7 @@ class DBHandler:
             username (str): public username
             is_bot (bool): type of user
             auth_id (str): authenticate token
+            token_ttl (int): time to live auth_id token
             email (str): user email
             avatar (bytes): user image or photo
             bio (str): text information about user
@@ -410,7 +410,7 @@ class DBHandler:
                     key: bytes = None,
                     salt: bytes = None) -> str:
         """
-        Updating information in the table UserConfig
+        Updating information in the table UserConfig.
 
         Args:
             uuid (str): unique user identify number
@@ -420,6 +420,7 @@ class DBHandler:
             username (str): public username
             is_bot (bool): type of user
             auth_id (str): authenticate token
+            token_ttl (int): time to live auth_id token
             email (str): user email
             avatar (bytes): user image or photo
             bio (str): text information about user
@@ -430,6 +431,7 @@ class DBHandler:
             (str): message "Updated"
 
         """
+
         dbquery = self.__read_db(table="UserConfig",
                                  get_one=True,
                                  uuid=uuid)
@@ -501,8 +503,7 @@ class DBHandler:
     def get_message_by_text(self,
                             text: str) -> SelectResults:
         """
-        Gives out all message which contains in Message table and contain
-        desired text string.
+        Gives out all message which contains desired text string.
 
         Args:
             text (str): text string to be found

--- a/mod/db/models.py
+++ b/mod/db/models.py
@@ -1,22 +1,22 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import sqlobject as orm
@@ -63,8 +63,7 @@ class UserConfig(orm.SQLObject):
 
 class Flow(orm.SQLObject):
     """
-    Flow table containing information about threads and their types
-    (chat, channel, group).
+    Flow table containing information about threads and their types.
 
     Args:
         uuid (str, required, unique): unique flow id which automated
@@ -88,8 +87,7 @@ class Flow(orm.SQLObject):
 
 class Message(orm.SQLObject):
     """
-    Generates a Message table containing information
-    about user messages.
+    Message table containing information about user messages.
 
     Args:
         uuid (str, required, unique): unique flow id which automated
@@ -123,8 +121,7 @@ class Message(orm.SQLObject):
 
 class Admin(orm.SQLObject):
     """
-    Generates Admin table containing information
-    about users with administrators role.
+    Admin table containing information about users with administrators role.
 
     Args:
         username (str, required, unique): name user which granted administrator

--- a/mod/error.py
+++ b/mod/error.py
@@ -30,6 +30,8 @@ class ServerStatus(IntEnum):
     Notes:
         CLIENT_CLOSED_REQUEST - 499
 
+        VERSION_NOT_SUPPORTED - 505
+
         UNKNOWN_ERROR - 520
 
         INVALID_SSL_CERTIFICATE - 526

--- a/mod/error.py
+++ b/mod/error.py
@@ -1,31 +1,32 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
+
 from collections import namedtuple
-from http import HTTPStatus
 from enum import IntEnum
+from http import HTTPStatus
 
 
 class ServerStatus(IntEnum):
     """
-    Additional server status code and reason phrases
+    Additional server status code and reason phrases.
 
     Notes:
         CLIENT_CLOSED_REQUEST - 499
@@ -38,7 +39,14 @@ class ServerStatus(IntEnum):
 
     """
 
-    def __new__(cls, value, phrase, description=''):
+    def __new__(cls,
+                value,
+                phrase,
+                description=''):
+        """
+        Optional class constructor.
+        """
+
         obj = int.__new__(cls, value)
         obj._value_ = value
         obj.phrase = phrase
@@ -61,8 +69,8 @@ class ServerStatus(IntEnum):
 
 def check_error_pattern(status: str) -> namedtuple:
     """
-    Checks the error name against the existing error types supported by
-    the server. The error name is passed as a "status" parameter.
+    Checks error name against existing error types supported by server.
+    The error name is passed as a "status" parameter.
 
     Args:
         status (str): error name

--- a/mod/lib.py
+++ b/mod/lib.py
@@ -1,36 +1,36 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
-import sys
 from hashlib import blake2b
 from hmac import compare_digest
 from os import urandom
+import sys
 
 from mod.config.config import ConfigHandler
 
 
 class Hash:
     """
-    Generates password hashes, hashes for sessions, authenticator token,
-    checks password hashes.
+    Generates hashes.
+    Hash for password, sessions, checks password hashes. Authenticator token.
 
     Args:
         password (str, required): password
@@ -129,8 +129,7 @@ class Hash:
 
     def auth_id(self) -> str:
         """
-        Generates an authenticator token for client session
-        connection to server.
+        Generating authenticator token for client session connection to server.
 
         Returns:
             (str): authenticate token

--- a/mod/logging.py
+++ b/mod/logging.py
@@ -1,22 +1,22 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import sys

--- a/mod/protocol/__init__.py
+++ b/mod/protocol/__init__.py
@@ -1,22 +1,22 @@
 """
-    Copyright (c) 2021 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2021 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
 __all__ = ["mtp"]

--- a/mod/protocol/matrix/__init__.py
+++ b/mod/protocol/matrix/__init__.py
@@ -1,22 +1,22 @@
 """
-    Copyright (c) 2021 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2021 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
 __all__ = ["worker"]

--- a/mod/protocol/matrix/api.py
+++ b/mod/protocol/matrix/api.py
@@ -1,20 +1,20 @@
 """
-    Copyright (c) 2021 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2021 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """

--- a/mod/protocol/matrix/worker.py
+++ b/mod/protocol/matrix/worker.py
@@ -1,22 +1,22 @@
 """
-    Copyright (c) 2021 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2021 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from mod.db.dbhandler import DBHandler
@@ -46,7 +46,7 @@ class MatrixProtocol:
     @staticmethod
     def get_response() -> str:
         """
-        Generates a JSON-object containing result of an instance json
+        Generates a JSON-object containing result of an instance json.
 
         Returns:
                 (json): json-object which contains validated response

--- a/mod/protocol/mtp/__init__.py
+++ b/mod/protocol/mtp/__init__.py
@@ -1,22 +1,22 @@
 """
-    Copyright (c) 2021 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2021 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
 __all__ = ["worker"]

--- a/mod/protocol/mtp/api.py
+++ b/mod/protocol/mtp/api.py
@@ -1,27 +1,27 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from typing import Any
-from typing import Optional
 from typing import List
+from typing import Optional
 
 from pydantic import BaseModel
 from pydantic import EmailStr
@@ -35,12 +35,11 @@ REVISION = '17'
 
 class BaseFlow(BaseModel):
     """
-    A base class that describes the validation of the Flow object the same for
-    requests and responses.
+    Base class describes validation of the Flow object.
     """
 
     time: Optional[int] = None
-    type: Optional[str] = None
+    type: Optional[str] = None  # noqa
     title: Optional[str] = None
     info: Optional[str] = None
     owner: Optional[str] = None
@@ -51,8 +50,7 @@ class BaseFlow(BaseModel):
 
 class BaseUser(BaseModel):
     """
-    A base class that describes the validation of the User object the same for
-    requests and responses.
+    Base class describes validation of the User object.
     """
 
     uuid: Optional[str] = None
@@ -69,8 +67,7 @@ class BaseUser(BaseModel):
 
 class BaseMessage(BaseModel):
     """
-    A base class that describes the validation of the Message object the same
-    for requests and responses.
+    Base class describes validation Message object.
     """
 
     uuid: str
@@ -89,8 +86,7 @@ class BaseMessage(BaseModel):
 
 class BaseData(BaseModel):
     """
-    A base class that describes the validation of the Data object the same for
-    requests and responses.
+    Base class describes validation of the Data object.
     """
 
     time: Optional[int] = None
@@ -100,8 +96,7 @@ class BaseData(BaseModel):
 
 class BaseErrors(BaseModel):
     """
-    A base class that describes the validation of the Errors object the same
-    for requests and responses.
+    Base class describes validation of the Errors object.
     """
 
     detail: Optional[str] = None
@@ -109,8 +104,7 @@ class BaseErrors(BaseModel):
 
 class BaseVersion(BaseModel):
     """
-    A base class that describes the validation of the Jsonapi object the same
-    for requests and responses.
+    Base class describes validation of the Jsonapi object.
     """
 
     version: str
@@ -119,11 +113,10 @@ class BaseVersion(BaseModel):
 
 class BaseValidator(BaseModel):
     """
-    A base class that describes the validation of the main object the same for
-    requests and responses.
+    Base class describes validation of the Main object.
     """
 
-    type: str
+    type: str  # noqa
     jsonapi: BaseVersion
     meta: Optional[Any] = None
 
@@ -133,12 +126,12 @@ class BaseValidator(BaseModel):
 
 class FlowRequest(BaseFlow):
     """
-    Validation settings for the Flow object
+    Validation settings for the Flow object.
     """
 
     class Config:
         """
-        Additional configuration for Request
+        Additional configuration for Request.
         """
 
         title = 'List of flow with UUID is str or None'
@@ -147,12 +140,12 @@ class FlowRequest(BaseFlow):
 
 class UserRequest(BaseUser):
     """
-    Validation settings for the User object
+    Validation settings for the User object.
     """
 
     class Config:
         """
-        Additional configuration for Request
+        Additional configuration for Request.
         """
 
         title = 'List of user information'
@@ -160,12 +153,12 @@ class UserRequest(BaseUser):
 
 class MessageRequest(BaseMessage):
     """
-    Validation settings for the Message object
+    Validation settings for the Message object.
     """
 
     class Config:
         """
-        Additional configuration for Request
+        Additional configuration for Request.
         """
 
         title = 'List of message information with client_id is int'
@@ -175,12 +168,12 @@ class MessageRequest(BaseMessage):
 
 class DataRequest(BaseData):
     """
-    Validation settings for the Data object
+    Validation settings for the Data object.
     """
 
     class Config:
         """
-        Additional configuration for Request
+        Additional configuration for Request.
         """
 
         title = 'Main data-object'
@@ -191,12 +184,12 @@ class DataRequest(BaseData):
 
 class ErrorsRequest(BaseErrors):
     """
-    Validation settings for the Errors object
+    Validation settings for the Errors object.
     """
 
     class Config:
         """
-        Additional configuration for Request
+        Additional configuration for Request.
         """
 
         title = 'Error information'
@@ -208,12 +201,12 @@ class ErrorsRequest(BaseErrors):
 
 class VersionRequest(BaseVersion):
     """
-    Validation settings for the Jsonapi object
+    Validation settings for the Jsonapi object.
     """
 
     class Config:
         """
-        Additional configuration for Request
+        Additional configuration for Request.
         """
 
         title = 'Protocol version'
@@ -226,7 +219,7 @@ class Request(BaseValidator):
 
     class Config:
         """
-        Additional configuration for Request
+        Additional configuration for Request.
         """
 
         title = 'MoreliaTalk protocol (for request)'
@@ -240,12 +233,12 @@ class Request(BaseValidator):
 
 class FlowResponse(BaseFlow):
     """
-    Validation settings for the Flow object
+    Validation settings for the Flow object.
     """
 
     class Config:
         """
-        Additional configuration for Response
+        Additional configuration for Response.
         """
 
         title = 'List of flow with required UUID and it is str'
@@ -255,12 +248,12 @@ class FlowResponse(BaseFlow):
 
 class UserResponse(BaseUser):
     """
-    Validation settings for the User object
+    Validation settings for the User object.
     """
 
     class Config:
         """
-        Additional configuration for Response
+        Additional configuration for Response.
         """
 
         title = 'List of user information'
@@ -268,12 +261,12 @@ class UserResponse(BaseUser):
 
 class MessageResponse(BaseMessage):
     """
-    Validation settings for the Message object
+    Validation settings for the Message object.
     """
 
     class Config:
         """
-        Additional configuration for Response
+        Additional configuration for Response.
         """
 
         title = 'List of message information without client_id'
@@ -283,12 +276,12 @@ class MessageResponse(BaseMessage):
 
 class DataResponse(BaseData):
     """
-    Validation settings for the Data object
+    Validation settings for the Data object.
     """
 
     class Config:
         """
-        Additional configuration for Response
+        Additional configuration for Response.
         """
 
         title = 'Main data-object'
@@ -299,12 +292,12 @@ class DataResponse(BaseData):
 
 class ErrorsResponse(BaseErrors):
     """
-    Validation settings for the Errors object
+    Validation settings for the Errors object.
     """
 
     class Config:
         """
-        Additional configuration for Response
+        Additional configuration for Response.
         """
 
         title = 'Error information. Code, status. time is required'
@@ -316,12 +309,12 @@ class ErrorsResponse(BaseErrors):
 
 class VersionResponse(BaseVersion):
     """
-    Validation settings for the Jsonapi object
+    Validation settings for the Jsonapi object.
     """
 
     class Config:
         """
-        Additional configuration for Response
+        Additional configuration for Response.
         """
 
         title = 'Protocol version'
@@ -334,7 +327,7 @@ class Response(BaseValidator):
 
     class Config:
         """
-        Additional configuration for Response
+        Additional configuration for Response.
         """
 
         title = 'MoreliaTalk protocol (for response)'

--- a/mod/protocol/mtp/worker.py
+++ b/mod/protocol/mtp/worker.py
@@ -1,41 +1,41 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
+from collections import namedtuple
 import json
 from time import time
 from uuid import uuid4
-from collections import namedtuple
 
-from pydantic import ValidationError
 from loguru import logger
+from pydantic import ValidationError
 from sqlobject.sresults import SelectResults
 
-from mod.protocol.mtp import api
 from mod import error
 from mod import lib
-from mod.db.dbhandler import DBHandler
-from mod.db.dbhandler import DatabaseWriteError
-from mod.db.dbhandler import DatabaseReadError
-from mod.db.dbhandler import DatabaseAccessError
 from mod.config.config import ConfigHandler
+from mod.db.dbhandler import DatabaseAccessError
+from mod.db.dbhandler import DatabaseReadError
+from mod.db.dbhandler import DatabaseWriteError
+from mod.db.dbhandler import DBHandler
+from mod.protocol.mtp import api
 
 
 class MTPErrorResponse:
@@ -68,7 +68,6 @@ class MTPErrorResponse:
             object (api.ErrorResponse): object with information about code,
             status, time and detailed description of error that has occurred.
 
-            {'code': 200,'status': 'Ok','time': 123456545,'detail': 'successfully'}
         """
 
         try:
@@ -174,7 +173,7 @@ class MTProtocol:
                     uuid: str,
                     auth_id: str) -> namedtuple:
         """
-        Checking user authentication every each request
+        Checking user authentication every each request.
 
         Args:
             uuid (str): user identification number which granted moreliatalk
@@ -216,7 +215,7 @@ class MTProtocol:
     def get_response(self,
                      response: api.Response = None) -> json:
         """
-        Generates a JSON-object containing result of an instance json
+        Generates a JSON-object containing result of an instance json.
 
         Returns:
             (json): json-object which contains validated response
@@ -233,14 +232,14 @@ class MTProtocol:
     def _check_login(self,
                      login: str) -> bool:
         """
-        Checks database for a user with the same login and returns True
-        if there is such a user or False if no such user exists.
+        Checks database for a user with the same login.
 
         Args:
             login (str): user login
 
         Returns:
-            (bool): True of False
+            (bool): True if there is such a user or False if no such user
+                exists.
         """
 
         try:
@@ -435,8 +434,8 @@ class MTProtocol:
     def _all_messages(self,
                       request: api.Request) -> api.Response:
         """
-        Displays all messages of a specific flow retrieves them
-        from database and issues them as an array consisting of JSON.
+        Displays all messages of a specific flow.
+        Retrieves from database and issues them as an array consisting of JSON.
 
         See Also:
             https://github.com/MoreliaTalk/morelia_protocol
@@ -463,8 +462,8 @@ class MTProtocol:
                          end: int,
                          start: int = 0) -> list[api.MessageResponse]:
             """
-            Converts the database object into a list of validated "Message"
-            objects.
+            Converts the database object into a list.
+            List contains validation Message object.
 
             Args:
                 db (SelectResults): database query result
@@ -479,24 +478,24 @@ class MTProtocol:
 
             for element in db[start:end]:
                 _list.append(api.MessageResponse(
-                               uuid=element.uuid,
-                               client_id=None,
-                               text=element.text,
-                               from_user=element.user.uuid,
-                               time=element.time,
-                               from_flow=element.flow.uuid,
-                               file_picture=element.file_picture,
-                               file_video=element.file_video,
-                               file_audio=element.file_audio,
-                               file_document=element.file_document,
-                               emoji=element.emoji,
-                               edited_time=element.edited_time,
-                               edited_status=element.edited_status))
+                             uuid=element.uuid,
+                             client_id=None,
+                             text=element.text,
+                             from_user=element.user.uuid,
+                             time=element.time,
+                             from_flow=element.flow.uuid,
+                             file_picture=element.file_picture,
+                             file_video=element.file_video,
+                             file_audio=element.file_audio,
+                             file_document=element.file_document,
+                             emoji=element.emoji,
+                             edited_time=element.edited_time,
+                             edited_status=element.edited_status))
             return _list
 
         try:
             dbquery = self._db.get_message_by_more_time_and_flow(flow_uuid,
-                                                                 request.data.time)
+                                                                 request.data.time)  # noqa
             MESSAGE_COUNT = dbquery.count()
             dbquery[0]
         except DatabaseReadError as flow_error:
@@ -591,8 +590,7 @@ class MTProtocol:
     def _all_flow(self,
                   request: api.Request) -> api.Response:
         """
-        Allows to get a list of all flows and information about them
-        from database.
+        Get a list of all flows and information about them.
 
         See Also:
             https://github.com/MoreliaTalk/morelia_protocol
@@ -670,8 +668,8 @@ class MTProtocol:
     def _authentication(self,
                         request: api.Request) -> api.Response:
         """
-        Performs authentication of registered client,
-        with issuance of a unique hash number of connection session.
+        Performs authentication of registered client.
+        With issuance of a unique hash number of connection session.
         During authentication password transmitted by client
         and password contained in server database are verified.
 
@@ -755,8 +753,7 @@ class MTProtocol:
     def _delete_message(self,
                         request: api.Request) -> api.Response:
         """
-        Function deletes the message from database Message
-        table by its ID.
+        Deletes the message from database Message table by its ID.
 
         See Also:
             https://github.com/MoreliaTalk/morelia_protocol
@@ -820,8 +817,7 @@ class MTProtocol:
     def _ping_pong(self,
                    request: api.Request) -> api.Response:
         """
-        Generates a response to a client's request
-        for communication between server and client.
+        Simple response/request communication between server and client.
 
         See Also:
             https://github.com/MoreliaTalk/morelia_protocol

--- a/server.py
+++ b/server.py
@@ -1,61 +1,52 @@
 """
-    Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
-    Look at the file AUTHORS.md(located at the root of the project) to get the
-    full list.
+Copyright (c) 2020 - present NekrodNIK, Stepan Skriabin, rus-ai and other.
+Look at the file AUTHORS.md(located at the root of the project) to get the
+full list.
 
-    This file is part of Morelia Server.
+This file is part of Morelia Server.
 
-    Morelia Server is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Morelia Server is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Morelia Server is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+Morelia Server is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
 
-# ************** Standart module *********************
-import os
 from datetime import datetime
 from json import JSONDecodeError
-# ************** Standart module end *****************
+import logging as standart_logging
+import os
 
-
-# ************** External module *********************
 from fastapi import FastAPI
 from fastapi import Request
 from fastapi import WebSocket
 from fastapi.staticfiles import StaticFiles
+from loguru import logger
 from starlette.responses import HTMLResponse
 from starlette.templating import Jinja2Templates
 from starlette.websockets import WebSocketDisconnect
-# ************** External module end *****************
 
-
-# ************** Morelia module **********************
-from mod.controller import MainHandler
-from mod.db.dbhandler import DBHandler
 from admin import admin
 from mod.config.config import ConfigHandler
-# ************** Morelia module end ******************
-
-
-# ************** Logging beginning *******************
-from loguru import logger
+from mod.controller import MainHandler
+from mod.db.dbhandler import DBHandler
 from mod.logging import add_logging
-import logging as standart_logging
-# ************** Unicorn logger off ******************
+
+
 # Get parameters contains in config.ini
 config = ConfigHandler()
 config_option = config.read()
+
+# Unicorn logger off
 if config_option.uvicorn_logging_disable:
     standart_logging.disable()
-# ************** Logging end *************************
 
 # loguru logger on
 add_logging(config_option.level)
@@ -94,7 +85,7 @@ app.mount("/static",
 @app.get('/')
 def home_page(request: Request):
     """
-    Rendered home page where presents information about current working server
+    Rendered home page where presents information about current working server.
 
     Args:
         request(Request): not used
@@ -111,8 +102,7 @@ def home_page(request: Request):
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
     """
-    Responsible for establishing a websocket connection between server and
-    client and exchanging requests/responses.
+    Responsible for establishing a websocket connection.
 
     Notes:
         Waiting for client to connect via websockets, after which receive a
@@ -150,10 +140,10 @@ async def websocket_endpoint(websocket: WebSocket):
             # create a "client" object and pass the request body to
             # it as a parameter. The "get_response" method generates
             # a response in JSON-object format.
-            client_request = MainHandler(request=data,
-                                         database=db_connect,
-                                         protocol='mtp')
-            response = await websocket.send_bytes(client_request.get_response())
+            request = MainHandler(request=data,
+                                  database=db_connect,
+                                  protocol='mtp')
+            response = await websocket.send_bytes(request.get_response())
             logger.info("Response sent to client")
             logger.debug(f"Result of processing: {response}")
         # After disconnecting the client (by the decision of the client,

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,17 @@ precision = 0
 
 [flake8]
 max-line-length = 79
+# D107 - Missing docstring in __init__
+# D202 - No blank lines allowed after function docstring
+# D203 - 1 blank line required before class docstring
+# D204 - 1 blank line required after class docstring
+# D205 - 1 blank line required between summary line and description
+# F721 - syntax error in doctest
+# D212 - Multi-line docstring summary should start at the first line
+# D200 - One-line docstring should fit on one line with quotes
+# W293 - blank line contains whitespace
+ignore = D107,D202,D203,D204,D205,F721,D212,D200,W293
+application-import-names = morelia_server,tests,admin,mod
+import-order-style = google
+docstring-convention = google
+exclude = .github,.git,__pycache__,docs/source/conf.py,tests

--- a/tests/fixtures/config.ini
+++ b/tests/fixtures/config.ini
@@ -52,6 +52,12 @@ MESSAGES = 100
 USERS = 100
 
 
+[API_VERSION]
+# Maximum and minimum version of API which server supported
+MAX = 1.9
+MIN = 1.0
+
+
 [SUPERUSER]
 UUID = 123456789
 USERNAME = superuser

--- a/tests/fixtures/config.ini
+++ b/tests/fixtures/config.ini
@@ -54,8 +54,8 @@ USERS = 100
 
 [API_VERSION]
 # Maximum and minimum version of API which server supported
-MAX = 1.9
-MIN = 1.0
+MAX_VERSION = 1.9
+MIN_VERSION = 1.0
 
 
 [SUPERUSER]

--- a/tests/fixtures/valid_api_version.json
+++ b/tests/fixtures/valid_api_version.json
@@ -1,0 +1,15 @@
+{
+    "type": "ping-pong",
+    "data": {
+        "user": [{
+            "uuid": "123456",
+            "auth_id": "auth_id"
+            }],
+        "meta": null
+        },
+    "jsonapi": {
+        "version": "2.0",
+        "revision": "17"
+        },
+    "meta": null
+    }

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -18,6 +18,7 @@
     You should have received a copy of the GNU Lesser General Public License
     along with Morelia Server. If not, see <https://www.gnu.org/licenses/>.
 """
+
 import unittest
 from mod.config.validator import ConfigModel
 from pydantic.error_wrappers import ValidationError
@@ -44,6 +45,8 @@ class TestConfigValidator(unittest.TestCase):
                            folder=123156,
                            messages="1",
                            users=12345,
+                           max_version="1.9",
+                           min_version="0.9",
                            secret_key=123156)
         self.assertEqual(test.dict()["uri"], "123156")
         self.assertEqual(test.dict()["size_password"], 1)
@@ -58,6 +61,8 @@ class TestConfigValidator(unittest.TestCase):
         self.assertEqual(test.dict()["folder"], "123156")
         self.assertEqual(test.dict()["messages"], 1)
         self.assertEqual(test.dict()["users"], 12345)
+        self.assertEqual(test.dict()["max_version"], "1.9")
+        self.assertEqual(test.dict()["min_version"], "0.9")
         self.assertEqual(test.dict()["secret_key"], "123156")
 
     def test_not_valid_logging_section(self) -> None:
@@ -76,4 +81,6 @@ class TestConfigValidator(unittest.TestCase):
                           folder=123156,
                           messages="1",
                           users=12345,
+                          max_version="1.9",
+                          min_version="0.9",
                           secret_key=123156)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -89,7 +89,7 @@ class TestController(unittest.TestCase):
         run_handler = MainHandler(self.test,
                                   self.db,
                                   protocol='mtp')
-        result = json.loads(run_handler.mtp_handler())
+        result = json.loads(run_handler._mtp_handler())
         self.assertEqual(result['errors']['status'], 'OK')
         self.assertEqual(result['type'], 'get_update')
 


### PR DESCRIPTION
## Synopsis
Добавление линтера в соответстви с новыми правилами оформления кода. Также добавлена проверка сервером версии API используемого клиентом. При несоответствии версии API серврера и API клиента сервер выдаёт ошибку `VERSION_NOT_SUPPORTED` с кодом 505.

## Main changes

- Методы класса `MainHandler` - `mtp_handler()` и `matrix_handler()` теперь скрытые
- в `MTProtocol` добавлен метод `_check_protocol_version()`
- в `example_config.ini` и `config.ini` (в директории с тестами) добавлен раздел `[API_VERSION]` c параметрами `MAX_VERSION` и `MIN_VERSION`
- настройки flake8 и его плагинов размещены в `setup.cfg`

## Other important changes

- в документацию добавлено описание как вручную запустить тесты и линтер.
- добавлен тест на проверку работы метода `_check_protocol_version()`

### Closes issue and bug

Closes #162 
Closes #152 
Closes #116 
Closes #177 
Closes #155 