### PR TITLE
Исправлено падение теста, тикет issue #187

### DIFF
--- a/mod/db/dbhandler.py
+++ b/mod/db/dbhandler.py
@@ -31,7 +31,6 @@ from sqlobject.main import SQLObjectNotFound
 from sqlobject.sqlbuilder import AND
 from sqlobject.sresults import SelectResults
 
-from mod.config.config import ConfigHandler
 from mod.db import models
 
 
@@ -70,7 +69,7 @@ class DBHandler:
                         database tables
     """
 
-    __instance: Optional[ConfigHandler] = None
+    __instance: Optional['DBHandler'] = None
     _logger: Optional[str]
     _loglevel: Optional[str]
 
@@ -82,7 +81,7 @@ class DBHandler:
         And if not, creates a new one.
 
         Args:
-            cls(ConfigHandler): class ConfigHandler
+            cls: class DBHandler
             *args:
             **kwargs:
         """

--- a/mod/db/dbhandler.py
+++ b/mod/db/dbhandler.py
@@ -31,6 +31,7 @@ from sqlobject.main import SQLObjectNotFound
 from sqlobject.sqlbuilder import AND
 from sqlobject.sresults import SelectResults
 
+from mod.config.config import ConfigHandler
 from mod.db import models
 
 
@@ -69,8 +70,27 @@ class DBHandler:
                         database tables
     """
 
+    __instance: Optional[ConfigHandler] = None
     _logger: Optional[str]
     _loglevel: Optional[str]
+
+    def __new__(cls, *args, **kwargs):
+        """
+        A function called when creating a new object.
+
+        If such an object already exists, returns it.
+        And if not, creates a new one.
+
+        Args:
+            cls(ConfigHandler): class ConfigHandler
+            *args:
+            **kwargs:
+        """
+
+        if cls.__instance is None:
+            cls.__instance = super().__new__(cls)
+
+        return cls.__instance
 
     def __init__(self,
                  uri: str = 'sqlite:/:memory:',

--- a/tests/test_dbhandler.py
+++ b/tests/test_dbhandler.py
@@ -33,14 +33,13 @@ from mod.db.dbhandler import DatabaseReadError  # noqa
 
 
 class TestDBHandlerMainMethods(unittest.TestCase):
-    db: DBHandler
 
     @classmethod
     def setUpClass(cls) -> None:
         logger.remove()
-        cls.db = DBHandler(uri="sqlite:/:memory:")
 
     def setUp(self):
+        self.db = DBHandler(uri="sqlite:/:memory:")
         self.db.create_table()
 
     def tearDown(self):


### PR DESCRIPTION
## Synopsis
Класс DBHandler переделан в синглтон. И поправлены тесты в test_dbhandler.py

## Main changes

NaN

## Other important changes

NaN

## Self check [Running before create pull-request](https://moreliatalk.github.io/morelia_server/development.html#running-before-create-pool-request)

- [x] I checked the code with a static analyzer `mypy`?

- [x] I checked the code with a `flake8`?

- [x] I checked the code with a `Unittest`?

- [x] Have I written/corrected the documentation for the sections of code I added?

### Closes issue and bug

Closes #187 